### PR TITLE
GetProcessInstanceData.setFieldNames Bug fix 

### DIFF
--- a/force-app/main/default/classes/GetProcessInstanceData.cls
+++ b/force-app/main/default/classes/GetProcessInstanceData.cls
@@ -48,12 +48,26 @@ public with sharing class GetProcessInstanceData {
     }
 
     public static void setFieldNames(String fieldNames, Set<String> objectTypes) {
-
+        List<String> fieldNamesList = new List<String>();
+        if (fieldNames != null) {
+            fieldNamesList = fieldNames.split(',');
+        }
         for (String objectType : objectTypes) {
             String nameField = OBJECT_NAME_TO_NAME_FIELD.get(objectType);
             if (nameField != null) {
-                if (fieldNames == null || !fieldNames.toLowerCase().contains(nameField.toLowerCase())) {
+                if (fieldNames == null) {
                     FIELD_NAMES.add(nameField);
+                } else {
+                    Boolean found = false;
+                    for (String fieldName : fieldNamesList) {
+                        if (fieldName.toLowerCase().equals(nameField.toLowerCase())) {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) {
+                        FIELD_NAMES.add(nameField);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When you specify a custom field to display and the custom field api name contains Name, then the standard Name field from the object won't be pulled in. For example, I specified the custom field Project_Name__c to be shown in the datatable, but this caused the standard Name to be excluded.